### PR TITLE
Like source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "bugs": {
+    "url": "https://github.com/MobileChromeApps/cordova-plugin-android-support-v4/issues"
+  },
+  "bundleDependencies": false,
+  "contributors": [
+    {
+      "name": "Toniton"
+    }
+  ],
+  "cordova": {
+    "id": "cordova-plugin-android-support-v4",
+    "platforms": [
+      "android"
+    ]
+  },
+  "deprecated": false,
+  "description": "Cordova plugin to add android-support-v4.jar to Cordova/PhoneGap project",
+  "homepage": "https://github.com/toniton/cordova-plugin-android-support-v4/blob/master/README.md",
+  "keywords": [
+    "cordova",
+    "ecosystem:cordova",
+    "google",
+    "android",
+    "support",
+    "v4"
+  ],
+  "license": "MIT",
+  "name": "cordova-plugin-android-support-v4",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/toniton/cordova-plugin-android-support-v4.git"
+  },
+  "version": "21.0.1"
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,6 +14,6 @@
   <name>Android Support v4</name>
 
   <platform name="android">
-    <source-file src="android-support-v4.jar" target-dir="libs" />
+    <lib-file src="android-support-v4.jar"/>
   </platform>
 </plugin>


### PR DESCRIPTION
lib src with target-dir, copies the android support jar file to the libs folder. Therefore Cordova no longer detects an android studio project but instead sees it as an eclipse project as suggested by platforms/android/cordova/lib/AndroidStudio.js .

```
module.exports.isAndroidStudioProject = function isAndroidStudioProject (root) {
    var eclipseFiles = ['AndroidManifest.xml', 'libs', 'res'];
    var androidStudioFiles = ['app', 'app/src/main'];

    // assume it is an AS project and not an Eclipse project
    var isEclipse = false;
    var isAS = true;

    if (!fs.existsSync(root)) {
        throw new CordovaError('AndroidStudio.js:inAndroidStudioProject root does not exist: ' + root);
    }

    // if any of the following exists, then we are not an ASProj
    eclipseFiles.forEach(function (file) {
        if (fs.existsSync(path.join(root, file))) {
            isEclipse = true;
        }
    });

    // if it is NOT an eclipse project, check that all required files exist
    if (!isEclipse) {
        androidStudioFiles.forEach(function (file) {
            if (!fs.existsSync(path.join(root, file))) {
                console.log('missing file :: ' + file);
                isAS = false;
            }
        });
    }
    return (!isEclipse && isAS);
};
```

Thereby causing some issues.